### PR TITLE
rootfs_type: add default rootfs type for each device

### DIFF
--- a/templates/base/agl-base-defaults.jinja2
+++ b/templates/base/agl-base-defaults.jinja2
@@ -10,6 +10,7 @@
 {%- set device_type = device_type|default(yocto_machine+"-uboot") %}
 {%- set kernel_image = kernel_image|default('uImage') %}
 {%- set kernel_url = kernel_url|default(baseurl(kernel_image)) %}
+{%- set rootfs_type = rootfs_type|default("ramdisk") %}
 {%- if dtb %}
 {%- set dtb_url = dtb_url|default(baseurl(dtb)) %}
 {%- endif %}

--- a/templates/machines/dra7xx-evm.jinja2
+++ b/templates/machines/dra7xx-evm.jinja2
@@ -1,5 +1,6 @@
 {%- extends 'boot/generic-uboot-tftp.jinja2' %}
 {%- set device_type = "ti-vayu-uboot" %}
+{%- set rootfs_type = rfs_type|default("nbd") %}
 {%- set dtb = "zImage-dra7-evm-lcd-lg.dtb" %}
 {%- set kernel_image = "zImage" %}
 {%- set uboot_type = "bootz" %}

--- a/templates/machines/m3ulcb.jinja2
+++ b/templates/machines/m3ulcb.jinja2
@@ -1,5 +1,6 @@
 {%- extends 'boot/generic-uboot-tftp.jinja2' %}
 {%- set device_type = "r8a7796-m3ulcb" %}
+{%- set rootfs_type = rfs_type|default("nbd") %}
 {%- set kernel_image = "Image" %}
 {%- set dtb = "Image-r8a7796-m3ulcb.dtb" %}
 {%- set uboot_type = "booti" %}

--- a/templates/machines/porter.jinja2
+++ b/templates/machines/porter.jinja2
@@ -1,5 +1,6 @@
 {%- extends 'boot/generic-uboot-tftp.jinja2' %}
 {%- set device_type = "renesas-porter-uboot" %}
+{%- set rootfs_type = rfs_type|default("nbd") %}
 {%- set nbdinitrd = "initramfs-netboot-image-" + yocto_machine +".ext4.gz.u-boot" %}
 {%- set dtb = "uImage-r8a7791-porter.dtb" %}
 {%- set dl_dir = "porter-nogfx" %}

--- a/templates/machines/qemux86-64.jinja2
+++ b/templates/machines/qemux86-64.jinja2
@@ -1,5 +1,6 @@
 {%- extends 'boot/generic-qemu-tmpfs.jinja2' %}
 {%- set device_type = "qemu" %}
+{%- set rootfs_type = rfs_type|default("ramdisk") %}
 {%- set kernel_image = "bzImage" %}
 {%- set qemu_cmdline = "console=ttyS0,115200 root=/dev/hda debug verbose" %}
 {%- set qemu_args = "-cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt -m 1048 -soundhw hda" %}

--- a/templates/machines/raspberrypi3.jinja2
+++ b/templates/machines/raspberrypi3.jinja2
@@ -1,5 +1,7 @@
 {%- extends 'boot/generic-uboot-tftp.jinja2' %}
 {%- set device_type = "bcm2837-rpi-3-b" %}
+{%- set rootfs_type = rootfs_type|default("nbd") %}
 {%- set dtb = "uImage-bcm2710-rpi-3-b.dtb" %}
 {%- set nbdinitrd = "initramfs-netboot-image-" + yocto_machine +".ext4.gz.u-boot" %}
 {%- set nbdroot = "agl-demo-platform-" + yocto_machine + ".ext4.xz" %}
+

--- a/utils/agljobtemplate.py
+++ b/utils/agljobtemplate.py
@@ -43,7 +43,7 @@ class Agljobtemplate(object):
     def rfs_types(self):
         return self.RFS_TYPE
 
-    def render_job(self, url, machine, job_name = "AGL-short-smoke", priority = "medium", tests = [], rfs_type = "nbd"):
+    def render_job(self, url, machine, job_name = "AGL-short-smoke", priority = "medium", tests = [], rfs_type = None):
         test_templates = []
 
         if not machine in self.machines:
@@ -62,7 +62,9 @@ class Agljobtemplate(object):
         job['priority'] = priority
         job['urlbase'] = url
         job['test_templates'] =  test_templates
-        job['rootfs_type'] = rfs_type
+
+        if rfs_type is not None:
+            job['rootfs_type'] = rfs_type
 
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(self._template_path))
         env.filters['get_extension'] = get_extension

--- a/utils/create-jobs.py
+++ b/utils/create-jobs.py
@@ -16,7 +16,7 @@ def parse_cmdline(machines, tests, rfs_types):
     parser.add_argument('--urlbase', '-u', action='store', dest='urlbase',
                         help='url fetch base',
                         default='https://download.automotivelinux.org/AGL/upload/ci/')
-    parser.add_argument('--boot', action='store', dest='rfs_type', nargs = 1,
+    parser.add_argument('--boot', action='store', dest='rfs_type',
                         choices=rfs_types, help='select boot type')
     parser.add_argument('--test', dest='tests',  action='store', choices=tests + ["all"],
                         help='add these test to the job', nargs='*', default = [])
@@ -46,7 +46,7 @@ def main():
             args.job_name += " - {}".format(args.job_index)
 
     job = ajt.render_job(args.urlbase, args.machine, tests = args.tests, priority = args.priority,
-                         rfs_type = args.rfs_type[0], job_name = args.job_name)
+                         rfs_type = args.rfs_type, job_name = args.job_name)
 
     if args.job_file is None:
         print job


### PR DESCRIPTION
Add a default rootfs type for each device. the type can still be
overridden from the command line. The 'boot' parameter is no longer
required with this change

Signed-off-by: Jerome Brunet <jbrunet@baylibre.com>