### PR TITLE
Add callback option to command line

### DIFF
--- a/templates/base/agl-base.jinja2
+++ b/templates/base/agl-base.jinja2
@@ -4,6 +4,9 @@
 metadata:
   image.type: 'AGL'
 {% endblock %}
+{% if callback_name %}
+{% include 'base/agl-callback.jinja2' %}
+{% endif %}
 {%- block main %}
 device_type: {{ device_type }}
 job_name: {{ name }}

--- a/templates/base/agl-callback.jinja2
+++ b/templates/base/agl-callback.jinja2
@@ -1,0 +1,11 @@
+{%- block notify -%}
+notify:
+  criteria:
+    status: finished
+  callback:
+    url: {{ backend_fqdn }}/callback/{{ callback_name }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+    method: POST
+    dataset: all
+    token: {{ lab_token }}
+    content-type: json
+{%- endblock %}

--- a/templates/callback/callback_readme.txt
+++ b/templates/callback/callback_readme.txt
@@ -1,0 +1,19 @@
+## The callbacks info must be in this repo ##
+- - - -
+
+### Requirements: ###
+
+* Filetype: .cfg
+* Filename: <LAB_NAME>.cfg
+    * [default] section
+    * backend_fqdn = "The FQDN of the kernelCI backend to callback"
+    * lab_name = "The lab name as registered for the kernelCI backend"
+    * lab_token = "The kernelCI backend lab token"
+
+Example file: lab-mylab.cfg
+`
+[default]
+backend_fqdn = http(s)://api.mylab.com
+lab_name = lab-mylab
+lab_token = 123g5789-45f4-4f21-a485-7412589df235
+`

--- a/utils/create-jobs.py
+++ b/utils/create-jobs.py
@@ -20,6 +20,8 @@ def parse_cmdline(machines, tests, rfs_types):
                         default='https://download.automotivelinux.org/AGL/upload/ci/')
     parser.add_argument('--boot', action='store', dest='rfs_type', nargs=1, required=True,
                         choices=rfs_types, help='select boot type')
+    parser.add_argument('--callback', action='store', dest='callback',
+                        help='url to notify when job is done. Please read: templates/callback/callback_readme.txt')
     parser.add_argument('--test', dest='tests',  action='store', choices=tests + ['all'],
                         help="add these test to the job", nargs='*', default=[])
     parser.add_argument('-o', '--output', dest='job_file',  action='store',
@@ -50,7 +52,7 @@ def main():
             args.job_name += ' - {}'.format(args.job_index)
 
     job = ajt.render_job(args.urlbase, args.machine, tests=args.tests, priority=args.priority,
-                         rfs_type=args.rfs_type[0], job_name=args.job_name)
+                         rfs_type=args.rfs_type[0], job_name=args.job_name, kci_callback=args.callback)
 
     if args.job_file is None:
         print job


### PR DESCRIPTION
The callback option takes on argument. It should be the name of the file
located in ./templates/callback/ that contains all the "secret"
information such as the callback FQDN, lab name and token.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>