### PR TITLE
Add callback option to command line

### DIFF
--- a/templates/base/agl-base.jinja2
+++ b/templates/base/agl-base.jinja2
@@ -4,6 +4,9 @@
 metadata:
   image.type: 'AGL'
 {% endblock %}
+{% if callback_name %}
+{% include 'base/agl-callback.jinja2' %}
+{% endif %}
 {%- block main %}
 device_type: {{ device_type }}
 job_name: {{ name }}

--- a/templates/base/agl-callback.jinja2
+++ b/templates/base/agl-callback.jinja2
@@ -1,0 +1,11 @@
+{%- block notify -%}
+notify:
+  criteria:
+    status: finished
+  callback:
+    url: {{ backend_fqdn }}/callback/{{ callback_name }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+    method: POST
+    dataset: all
+    token: {{ lab_token }}
+    content-type: json
+{%- endblock %}

--- a/templates/callback/callback_readme.txt
+++ b/templates/callback/callback_readme.txt
@@ -1,0 +1,19 @@
+## The callbacks info must be in this repo ##
+- - - -
+
+### Requirements: ###
+
+* Filetype: .cfg
+* Filename: <LAB_NAME>.cfg
+    * [default] section
+    * backend_fqdn = "The FQDN of the kernelCI backend to callback"
+    * lab_name = "The lab name as registered for the kernelCI backend"
+    * lab_token = "The kernelCI backend lab token"
+
+Example file: lab-mylab.cfg
+`
+[default]
+backend_fqdn = http(s)://api.mylab.com
+lab_name = lab-mylab
+lab_token = 123g5789-45f4-4f21-a485-7412589df235
+`

--- a/utils/agljobtemplate.py
+++ b/utils/agljobtemplate.py
@@ -2,17 +2,31 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import jinja2
+import ConfigParser
 
 
 def get_extension(path):
     return path.split('.')[-1]
 
 
+def parse_callback_file(template_path, callback_file, job):
+    callback_file_path = template_path + '/callback/' + callback_file + '.cfg'
+    try:
+        with open(callback_file_path):
+            cfg = ConfigParser.ConfigParser()
+            cfg.read(callback_file_path)
+            job['backend_fqdn'] = cfg.get('default', 'backend_fqdn')
+            job['lab_name'] = cfg.get('default', 'lab_name')
+            job['lab_token'] = cfg.get('default', 'lab_token')
+    except IOError:
+        raise IOError, "Unable to read from file {}".format(callback_file_path)
+
+
 class Agljobtemplate(object):
 
     DEFAULT_PATH = "templates"
+    CALLBACK_DIR = "callback"
     MACHINES_DIR = "machines"
     TESTS_DIR = "tests"
     RFS_TYPE = ['nfs', 'nbd', 'ramdisk']
@@ -45,7 +59,8 @@ class Agljobtemplate(object):
     def rfs_types(self):
         return self.RFS_TYPE
 
-    def render_job(self, url, machine, job_name="AGL-short-smoke", priority="medium", tests=[], rfs_type=None):
+    def render_job(self, url, machine, job_name="AGL-short-smoke", priority="medium", tests=[], rfs_type=None,
+                   kci_callback=None):
         test_templates = []
 
         if machine not in self.machines:
@@ -67,6 +82,13 @@ class Agljobtemplate(object):
 
         if rfs_type is not None:
             job['rootfs_type'] = rfs_type
+
+        if kci_callback:
+            if test_templates:
+                job['callback_name'] = 'lava/test'
+            else:
+                job['callback_name'] = 'lava/boot'
+            parse_callback_file(self._template_path, kci_callback, job)
 
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(self._template_path))
         env.filters['get_extension'] = get_extension

--- a/utils/create-jobs.py
+++ b/utils/create-jobs.py
@@ -20,6 +20,8 @@ def parse_cmdline(machines, tests, rfs_types):
                         default='https://download.automotivelinux.org/AGL/upload/ci/')
     parser.add_argument('--boot', action='store', dest='rfs_type',
                         choices=rfs_types, help='select boot type')
+    parser.add_argument('--callback', action='store', dest='callback',
+                        help='url to notify when job is done. Please read: ./templates/callback/callback_readme.txt')
     parser.add_argument('--test', dest='tests',  action='store', choices=tests + ['all'],
                         help="add these test to the job", nargs='*', default=[])
     parser.add_argument('-o', '--output', dest='job_file',  action='store',
@@ -50,7 +52,7 @@ def main():
             args.job_name += ' - {}'.format(args.job_index)
 
     job = ajt.render_job(args.urlbase, args.machine, tests=args.tests, priority=args.priority,
-                         rfs_type=args.rfs_type, job_name=args.job_name)
+                         rfs_type=args.rfs_type, job_name=args.job_name, kci_callback=args.callback)
 
     if args.job_file is None:
         print job


### PR DESCRIPTION
The callback option takes one argument. It is the name of the file
located in ./templates/callback/ that contains all the "secret"
information such as the callback FQDN, lab name and token.
A readme is provided: ./templates/callback/callback_readme.txt

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>