### PR TITLE
Do not require jobid argument

### DIFF
--- a/utils/create-jobs.py
+++ b/utils/create-jobs.py
@@ -27,7 +27,7 @@ def parse_cmdline(machines, tests, rfs_types):
     parser.add_argument('-n', '--name', dest='job_name',  action='store',
                         help="job name", default='AGL-short-smoke-wip')
     parser.add_argument('-j', '--jobid', dest='job_id',  action='store',
-                        help='job id for link creation: URLBASE/JOB_ID', required=True)
+                        help='job id for link creation: URLBASE/JOB_ID')
     parser.add_argument('-i', '--jobidx', dest='job_index',  action='store',
                         help='job index for link creation: URLBASE/JOB_ID/JOB_INDEX', default='1')
 


### PR DESCRIPTION
Do not require jobid argument as it's too specific to one url.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>